### PR TITLE
Fix Method `send_many` takes `wires` as Object instead of array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADS client server argument
 ### Fixed
 - Protect 'get_log' method
+- Method `send_many` takes `wires` as Object instead of array
 
 ## [1.2.1] - 2018-12-30
 ### Fixed

--- a/ads-json-rpc
+++ b/ads-json-rpc
@@ -268,7 +268,7 @@ def send_one(**kwargs):
 
 @jsonrpc.method('send_many')
 def send_many(**kwargs):
-    validate_params(send_many, kwargs, transaction=True, required={'wires': Array})
+    validate_params(send_many, kwargs, transaction=True, required={'wires': Object})
     #validate_params(send_one, kwargs['wires'], required={'x': Number})
     return run_write_command('send_many', kwargs)
 


### PR DESCRIPTION
Object is saupperted by `ads` client, while array not.